### PR TITLE
Unified and automated benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+LANGUAGES = c cpp erlang go java js perl python rust
+LENGTH = 13
+
+default: $(LANGUAGES) RUN
+
+$(LANGUAGES): RUN
+	$(MAKE) -C $@ LENGTH=$(LENGTH)
+
+RUN:

--- a/c/Makefile
+++ b/c/Makefile
@@ -6,4 +6,4 @@ CC=gcc
 default:
 	$(CC) $(CFLAGS) -Dkmer_length=$(LENGTH) main.c -o c
 	$(info C)
-	c
+	./c

--- a/c/Makefile
+++ b/c/Makefile
@@ -4,4 +4,6 @@ CC=gcc
 # build with make LENGTH=yourNumber
 # e.g.: make LENGTH=15 
 default:
-	$(CC) $(CFLAGS) -Dkmer_length=$(LENGTH) main.c
+	$(CC) $(CFLAGS) -Dkmer_length=$(LENGTH) main.c -o c
+	$(info C)
+	c

--- a/c/main.c
+++ b/c/main.c
@@ -58,7 +58,7 @@ static uint64_t ns(void) {
 }
 
 bool is_done(char *s) {
-  for (int i = 0; i < kmer_Length; i++) {
+  for (int i = 0; i < kmer_length; i++) {
     if (s[i] != 'T')
       return false;
   }

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -6,4 +6,4 @@ CC=g++
 default:
 	$(CC) $(CFLAGS) -Dkmer_length=$(LENGTH) main.cc -o cc
 	$(info C++)
-	cc
+	./cc

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -4,4 +4,6 @@ CC=g++
 # build with make LENGTH=yourNumber
 # e.g.: make LENGTH=15 
 default:
-	$(CC) $(CFLAGS) -Dkmer_length=$(LENGTH) main.cc
+	$(CC) $(CFLAGS) -Dkmer_length=$(LENGTH) main.cc -o cc
+	$(info C++)
+	cc

--- a/erlang/Makefile
+++ b/erlang/Makefile
@@ -1,0 +1,3 @@
+default:
+	erl -noshell -eval 'compile:file(kmer), kmer:calculate($(LENGTH))' -s erlang halt
+  $(info Erlang)

--- a/go/Makefile
+++ b/go/Makefile
@@ -1,0 +1,3 @@
+default:
+	go run main.go $(LENGTH)
+	$(info Go)

--- a/go/main.go
+++ b/go/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"os"
+	"strconv"
 	"time"
 )
 
@@ -20,9 +22,11 @@ func convert(c byte) byte {
 	return ' '
 }
 
-const length = 15
-
 func main() {
+	length, err := strconv.Atoi(os.Args[1])
+	if err != nil {
+		panic(err)
+	}
 	start := time.Now()
 	base := "ACGT"
 	end := base[len(base) - 1]

--- a/java/Makefile
+++ b/java/Makefile
@@ -1,0 +1,3 @@
+default:
+	java -Dlength="$(LENGTH)" ./src/Main.java
+	$(info Java)

--- a/java/src/Main.java
+++ b/java/src/Main.java
@@ -1,18 +1,17 @@
 import java.util.Arrays;
 
 public class Main {
-	static int LENGTH = 15;
-
 	public static void main(String[] args) {
+		var length = Integer.parseInt(System.getProperty("length"));
 		var start = System.nanoTime();
 		var base = "ACGT";
 		var end = base.charAt(base.length() - 1);
 		var s = "";
-		for (var i = 0; i < LENGTH; i++) {
+		for (var i = 0; i < length; i++) {
 			s += base.charAt(0);
 		}
 		var sLast = "";
-		for (var i = 0; i < LENGTH; i++) {
+		for (var i = 0; i < length; i++) {
 			sLast += end;
 		}
 		var ss = s.toCharArray();
@@ -21,7 +20,7 @@ public class Main {
 		while (!Arrays.equals(ss, ssLast)) {
 			counter++;
 			// System.out.println(new String(ss));
-			for (var i = 0; i < LENGTH; i++) {
+			for (var i = 0; i < length; i++) {
 				var old = ss[i];
 				ss[i] = convert(old);
 				if (old != end) {
@@ -30,7 +29,7 @@ public class Main {
 			}
 		}
 		var delta = System.nanoTime() - start;
-		System.out.printf("Number of generated k-mers: %d - took %dms", counter, (delta / 1000) / 1000);
+		System.out.printf("Number of generated k-mers: %d - took %dms\n", counter, (delta / 1000) / 1000);
 	}
 
 	public static char convert(char c) {

--- a/js/Makefile
+++ b/js/Makefile
@@ -1,0 +1,3 @@
+default:
+	node main.js $(LENGTH)
+	$(info JavaScript)

--- a/js/main.js
+++ b/js/main.js
@@ -16,13 +16,12 @@ const convert = c => {
   return " ";
 };
 
+const lenStr = parseInt(process.argv[2]);
 const timeStart = performance.now();
-console.log("Start");
 
 const opt = "ACGT";
 let s = "";
 let sLast = "";
-const lenStr = 13;
 
 for (let i = 0; i < lenStr; i++) {
   s += opt[0];

--- a/perl/Makefile
+++ b/perl/Makefile
@@ -1,0 +1,3 @@
+default:
+	perl main.pl $(LENGTH)
+	$(info Perl)

--- a/perl/main.pl
+++ b/perl/main.pl
@@ -1,3 +1,5 @@
+use Time::HiRes qw(time);
+
 my %map = (
     A => 'C',
     C => 'G',
@@ -6,12 +8,9 @@ my %map = (
 );
 
 my $start = time();
-print "Start
-
-";
+my $len_str = $ARGV[0] + 0;
 
 my @opt = split //, "ACGT";
-my $len_str = 13;
 my $s = $opt[0] x $len_str;
 my $s_last = $opt[-1] x $len_str;
 my $last_char = $opt[-1];
@@ -28,8 +27,4 @@ while ($s ne $s_last) {
 
 my $elapsed = time() - $start;
 print "Number of generated k-mers: $counter - took ", $elapsed*1000, "ms
-
-";
-print "Finish!
-
 ";

--- a/python/Makefile
+++ b/python/Makefile
@@ -1,0 +1,3 @@
+default:
+	python main.py $(LENGTH)
+	$(info Python)

--- a/python/main.py
+++ b/python/main.py
@@ -1,5 +1,5 @@
 import time
-
+from sys import argv
 
 def convert(c):
 	if c == 'A':
@@ -13,12 +13,11 @@ def convert(c):
 
 
 time_start = time.time()
-print("Start")
 
 opt = "ACGT"
 s = ""
 s_last = ""
-len_str = 13
+len_str = int(argv[1])
 
 for i in range(len_str):
 	s += opt[0]
@@ -41,4 +40,3 @@ while s != s_last:
 # print(s)
 time_elapsed = time.time() - time_start
 print("Number of generated k-mers: {} - took {}ms".format(counter, time_elapsed * 1000))
-print("Finish!")

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -1,0 +1,3 @@
+default:
+	cargo run --release $(LENGTH)
+	$(info Rust)

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -4,13 +4,11 @@ fn main() {
     // get current nano time
     let start = Instant::now();
 
-    println!("Start");
-
     let opt = "ACGT";
     let end = opt.chars().last().unwrap();
     let mut s = "".to_owned();
     let mut s_last = "".to_owned();
-    let len_str = 13;
+    let len_str = std::env::args().nth(1).unwrap().parse::<usize>().unwrap();
 
     for _ in 0..len_str {
         s += &opt.chars().nth(0).unwrap().to_string();
@@ -44,7 +42,6 @@ fn main() {
         counter,
         duration.as_millis()
     );
-    println!("End");
 }
 
 fn convert(c: char) -> char {


### PR DESCRIPTION
Example run:
```
$ make LENGTH=11 -s
C
Nummer of generated k-mers: 4194304 - took 6ms
C++
Nummer of generated k-mers: 4194304 - took 6ms
Erlang
Nummer of generated k-mers: 4194304 - took 761ms
Go
Number of generated k-mers: 4194304 - took 30.0552ms
Java
Number of generated k-mers: 4194304 - took 36ms
JavaScript
Number of generated k-mers: 4194304 - took 157.83059990406036ms
Perl
Number of generated k-mers: 4194304 - took 1247.50900268555ms
Python
Number of generated k-mers: 4194304 - took 3605.271577835083ms
Rust
warning: crate `HelloFerris` should have a snake case name
  |
  = help: convert the identifier to snake case: `hello_ferris`
  = note: `#[warn(non_snake_case)]` on by default

warning: `HelloFerris` (bin "HelloFerris") generated 1 warning
    Finished release [optimized] target(s) in 0.01s
     Running `target\release\HelloFerris.exe 11`
Nummer of generated k-mers: 4194304 - took 32ms
```
With selected languages:
```
$ make LENGTH=13 LANGUAGES="go c cpp rust" -s
Go
Number of generated k-mers: 67108864 - took 497.3457ms
C
Nummer of generated k-mers: 67108864 - took 67ms
C++
Nummer of generated k-mers: 67108864 - took 108ms
Rust
warning: crate `HelloFerris` should have a snake case name
  |
  = help: convert the identifier to snake case: `hello_ferris`
  = note: `#[warn(non_snake_case)]` on by default

warning: `HelloFerris` (bin "HelloFerris") generated 1 warning
    Finished release [optimized] target(s) in 0.01s
     Running `target\release\HelloFerris.exe 13`
Nummer of generated k-mers: 67108864 - took 497ms
```
Should help a lot running benchmarks 😉 