### PR TITLE
Docker image for easier benchmarks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# WSL has performance issues
+# use a native linux machine + Docker for better results
+
+FROM alpine:3.17
+RUN apk add gcc g++ make erlang rust cargo cabal wget nodejs npm bash perl go openjdk17
+
+RUN cabal update
+
+# .NET
+RUN wget https://dot.net/v1/dotnet-install.sh
+RUN chmod +x ./dotnet-install.sh
+RUN ./dotnet-install.sh --version latest
+ENV PATH="/root/.dotnet:${PATH}"
+
+# Python 3.11
+COPY --from=python:3.11.0-alpine3.17 usr/local/bin/ usr/local/bin/
+COPY --from=python:3.11.0-alpine3.17 /usr/local/lib/ /usr/local/lib/
+ENV PATH="/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${PATH}"
+
+# Coffe script
+RUN npm install --global coffeescript
+
+COPY . .
+
+# Prebuilt everything
+RUN make LENGTH=1
+CMD [ "/bin/bash" ]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-LANGUAGES = c cpp erlang go java js perl python rust haskell csharp
+LANGUAGES = c cpp erlang go java js perl python rust haskell csharp coffeescript
 LENGTH = 13
 
 default: $(LANGUAGES) RUN

--- a/c/main.c
+++ b/c/main.c
@@ -96,5 +96,5 @@ int main(void) {
     }
   }
   uint64_t delta = ((ns() - start) / 1000) / 1000;
-  printf("Nummer of generated k-mers: %lld - took %lldms\n", counter, delta);
+  printf("Number of generated k-mers: %lld - took %lldms\n", counter, delta);
 }

--- a/coffeescript/Makefile
+++ b/coffeescript/Makefile
@@ -1,0 +1,4 @@
+default:
+	coffee -c main.coffee
+	node main.js $(LENGTH)
+	$(info CoffeeScript (JS))

--- a/cpp/main.cc
+++ b/cpp/main.cc
@@ -55,5 +55,5 @@ int main()
   }
   auto t2 = Clock::now();
   auto delta = ((t2 - t1).count() / 1000) / 1000;
-  std::cout << "Nummer of generated k-mers: " << counter << " - took " << delta << "ms" << std::endl;
+  std::cout << "Number of generated k-mers: " << counter << " - took " << delta << "ms" << std::endl;
 }

--- a/erlang/kmer.erl
+++ b/erlang/kmer.erl
@@ -13,7 +13,7 @@ calculate(N) ->
   Now = get_timestamp(),
   Kmers = calculate(N, string:copies("A", N), string:copies("T", N)),
   Delta = get_timestamp() - Now,
-  io:fwrite("Nummer of generated k-mers: ~p - took ~pms~n", [Kmers, Delta]).
+  io:fwrite("Number of generated k-mers: ~p - took ~pms~n", [Kmers, Delta]).
 
 calculate(N, Start, Stop) -> calculate(N, Start, Stop, 1).
 

--- a/generate.sh
+++ b/generate.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+for i in $(seq $1 $2)
+do
+  make LENGTH=${i} > kmer${i}.txt
+  echo "Length ${i}"
+  cat kmer${i}.txt | sed -e '/.* - took .*/!d' | sed -r 's/Number of generated k-mers: .* - took (.*)/\1/g'
+done

--- a/haskell/app/Main.hs
+++ b/haskell/app/Main.hs
@@ -14,7 +14,7 @@ main = do
   count <- calculate num
   end <- getTime Monotonic
   let time = format timeSpecs start end
-  putStrLn (printf "Number of generated kmers: %d - took %s" count time)
+  putStrLn (printf "Number of generated k-mers: %d - took %s" count time)
 
 calculate :: Int -> IO Int
 calculate len = generate len (concat (replicate len "A")) (concat (replicate len "T")) 1

--- a/haskell/haskell.cabal
+++ b/haskell/haskell.cabal
@@ -30,7 +30,7 @@ executable haskell
     -- LANGUAGE extensions used by modules in this package.
     -- other-extensions:
     build-depends:
-        base ^>=4.16.1.0,
+        base ^>=4.15.1.0,
         clock == 0.8.3,
         formatting == 7.2.0
     hs-source-dirs:   app

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -38,7 +38,7 @@ fn main() {
 
     let duration = start.elapsed();
     println!(
-        "Nummer of generated k-mers: {} - took {}ms",
+        "Number of generated k-mers: {} - took {}ms",
         counter,
         duration.as_millis()
     );


### PR DESCRIPTION
Automatically collect data in a replicatable setup.
The times are in order of the languages of the root makefile.
In this case: c cpp erlang go java js perl python rust haskell csharp coffeescript
This should greatly improve benchmark ergonomics:
```
docker build -t kmers .
docker run --rm -it kmers
# ./generate.sh 1 10 >> data.txt
// ...
# cat ./datat.txt
Length 1
0ms
0ms
0ms
900ns
6ms
0.09780000150203705ms
0.00691413879394531ms
0.011205673217773438ms
0ms
21.70 us
4ms
0.09860000014305115ms
Length 2
0ms
0ms
0ms
1.5µs
6ms
0.10830000042915344ms
0.0159740447998047ms
0.035762786865234375ms
0ms
25.00 us
4ms
0.15049999952316284ms

// ....

Length 9
0ms
0ms
79ms
1.7404ms
26ms
25.1587999984622ms
217.288017272949ms
375.4754066467285ms
4ms
18.92 ms
15ms
27.703400000929832ms
Length 10
1ms
1ms
321ms
7.6643ms
34ms
63.43319999426603ms
832.498788833618ms
1416.322946548462ms
13ms
69.56 ms
47ms
62.549900002777576ms
````